### PR TITLE
Add whitelist for identity swaps

### DIFF
--- a/common/src/main/java/draylar/identity/api/platform/IdentityConfig.java
+++ b/common/src/main/java/draylar/identity/api/platform/IdentityConfig.java
@@ -76,6 +76,12 @@ public abstract class IdentityConfig {
 
     public abstract boolean enableSwaps();
 
+    /**
+     * Players listed here may swap identities even when {@link #enableSwaps()} is false.
+     * Names are compared case-insensitively.
+     */
+    public abstract List<String> allowedSwappers();
+
     public abstract int hostilityTime();
 
     public abstract boolean wardenIsBlinded();

--- a/common/src/main/java/draylar/identity/impl/tick/MenuKeyPressHandler.java
+++ b/common/src/main/java/draylar/identity/impl/tick/MenuKeyPressHandler.java
@@ -13,7 +13,10 @@ public class MenuKeyPressHandler implements ClientTickEvent.Client {
         assert client.player != null;
 
         if(IdentityClient.MENU_KEY.wasPressed()) {
-            if(IdentityConfig.getInstance().enableClientSwapMenu() || client.player.hasPermissionLevel(3)) {
+            if(IdentityConfig.getInstance().enableClientSwapMenu() ||
+                client.player.hasPermissionLevel(3) ||
+                IdentityConfig.getInstance().allowedSwappers().stream()
+                    .anyMatch(p -> p.equalsIgnoreCase(client.player.getGameProfile().getName()))) {
                 MinecraftClient.getInstance().setScreen(new IdentityScreen());
             }
         }

--- a/common/src/main/java/draylar/identity/network/impl/SwapPackets.java
+++ b/common/src/main/java/draylar/identity/network/impl/SwapPackets.java
@@ -25,7 +25,10 @@ public class SwapPackets {
 
                 context.getPlayer().getServer().execute(() -> {
                     // Ensure player has permission to switch identities
-                    if(IdentityConfig.getInstance().enableSwaps() || context.getPlayer().hasPermissionLevel(3)) {
+                    if(IdentityConfig.getInstance().enableSwaps() ||
+                        context.getPlayer().hasPermissionLevel(3) ||
+                        IdentityConfig.getInstance().allowedSwappers().stream()
+                            .anyMatch(p -> p.equalsIgnoreCase(context.getPlayer().getGameProfile().getName()))) {
                         // player type shouldn't be sent, but we still check regardless
                         if(entityType.equals(EntityType.PLAYER)) {
                             PlayerIdentity.updateIdentity((ServerPlayerEntity) context.getPlayer(), null, null);
@@ -43,7 +46,10 @@ public class SwapPackets {
             } else {
                 // Swap back to player if server allows it
                 context.getPlayer().getServer().execute(() -> {
-                    if(IdentityConfig.getInstance().enableSwaps() || context.getPlayer().hasPermissionLevel(3)) {
+                    if(IdentityConfig.getInstance().enableSwaps() ||
+                        context.getPlayer().hasPermissionLevel(3) ||
+                        IdentityConfig.getInstance().allowedSwappers().stream()
+                            .anyMatch(p -> p.equalsIgnoreCase(context.getPlayer().getGameProfile().getName()))) {
                         PlayerIdentity.updateIdentity((ServerPlayerEntity) context.getPlayer(), null, null);
                     }
 

--- a/fabric/src/main/java/draylar/identity/fabric/config/IdentityFabricConfig.java
+++ b/fabric/src/main/java/draylar/identity/fabric/config/IdentityFabricConfig.java
@@ -78,6 +78,9 @@ public class IdentityFabricConfig extends IdentityConfig implements Config {
     @Comment(value = "If set to false, only operators can switch identities. Used on the server; guaranteed to be authoritative.")
     public boolean enableSwaps = true;
 
+    @Comment(value = "List of player names allowed to swap identities when swaps are disabled.")
+    public List<String> allowedSwappers = new ArrayList<>();
+
     @Comment(value = "In blocks, how far can the Enderman ability teleport?")
     public int endermanAbilityTeleportDistance = 32;
 
@@ -336,6 +339,11 @@ public class IdentityFabricConfig extends IdentityConfig implements Config {
     @Override
     public boolean enableSwaps() {
         return enableSwaps;
+    }
+
+    @Override
+    public List<String> allowedSwappers() {
+        return allowedSwappers;
     }
 
     @Override

--- a/forge/src/main/java/draylar/identity/forge/config/IdentityForgeConfig.java
+++ b/forge/src/main/java/draylar/identity/forge/config/IdentityForgeConfig.java
@@ -44,6 +44,7 @@ public class IdentityForgeConfig extends IdentityConfig {
     public int maxHealth = 20;
     public boolean enableClientSwapMenu = true;
     public boolean enableSwaps = true;
+    public List<String> allowedSwappers = new ArrayList<>();
     public int endermanAbilityTeleportDistance = 32;
     public boolean showPlayerNametag = false;
     public boolean forceChangeNew = false;
@@ -277,6 +278,11 @@ public class IdentityForgeConfig extends IdentityConfig {
     @Override
     public boolean enableSwaps() {
         return enableSwaps;
+    }
+
+    @Override
+    public List<String> allowedSwappers() {
+        return allowedSwappers;
     }
 
     @Override


### PR DESCRIPTION
## Summary
- allow configuration of specific players who can use identity swaps
- expose the whitelist via `IdentityConfig`
- apply whitelist checks to swap packets and menu key handling

## Testing
- `gradle build` *(fails: Could not create an instance of LoomGradleExtensionImpl)*

------
https://chatgpt.com/codex/tasks/task_e_688cbb9b58888331bbb74c0b6cfa7c8c