### PR TITLE
Add morph whitelist command

### DIFF
--- a/common/src/main/java/draylar/identity/api/platform/IdentityConfig.java
+++ b/common/src/main/java/draylar/identity/api/platform/IdentityConfig.java
@@ -77,6 +77,12 @@ public abstract class IdentityConfig {
     public abstract boolean enableSwaps();
 
     /**
+     * Sets whether all players may swap identities regardless of the whitelist.
+     * When set to {@code false}, only operators or whitelisted players may swap.
+     */
+    public abstract void setEnableSwaps(boolean enabled);
+
+    /**
      * Players listed here may swap identities even when {@link #enableSwaps()} is false.
      * Names are compared case-insensitively.
      */

--- a/common/src/main/java/draylar/identity/command/IdentityCommand.java
+++ b/common/src/main/java/draylar/identity/command/IdentityCommand.java
@@ -1,6 +1,7 @@
 package draylar.identity.command;
 
 import com.mojang.brigadier.arguments.IntegerArgumentType;
+import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import dev.architectury.event.events.common.CommandRegistrationEvent;
 import draylar.identity.api.PlayerIdentity;
@@ -205,12 +206,53 @@ public class IdentityCommand {
                                     })
                             ).build();
 
+            LiteralCommandNode<ServerCommandSource> whitelistNode =
+                    CommandManager.literal("whitelist")
+                            .then(CommandManager.literal("enable")
+                                    .executes(ctx -> {
+                                        IdentityConfig.getInstance().setEnableSwaps(false);
+                                        if (IdentityConfig.getInstance().logCommands()) {
+                                            ctx.getSource().sendFeedback(() -> Text.literal("Enabled identity whitelist"), true);
+                                        }
+                                        return 1;
+                                    }))
+                            .then(CommandManager.literal("disable")
+                                    .executes(ctx -> {
+                                        IdentityConfig.getInstance().setEnableSwaps(true);
+                                        if (IdentityConfig.getInstance().logCommands()) {
+                                            ctx.getSource().sendFeedback(() -> Text.literal("Disabled identity whitelist"), true);
+                                        }
+                                        return 1;
+                                    }))
+                            .then(CommandManager.literal("add")
+                                    .then(CommandManager.argument("player", StringArgumentType.string())
+                                            .executes(ctx -> {
+                                                String name = StringArgumentType.getString(ctx, "player");
+                                                IdentityConfig.getInstance().allowedSwappers().add(name);
+                                                if (IdentityConfig.getInstance().logCommands()) {
+                                                    ctx.getSource().sendFeedback(() -> Text.literal("Added " + name + " to identity whitelist"), true);
+                                                }
+                                                return 1;
+                                            })))
+                            .then(CommandManager.literal("remove")
+                                    .then(CommandManager.argument("player", StringArgumentType.string())
+                                            .executes(ctx -> {
+                                                String name = StringArgumentType.getString(ctx, "player");
+                                                IdentityConfig.getInstance().allowedSwappers().removeIf(n -> n.equalsIgnoreCase(name));
+                                                if (IdentityConfig.getInstance().logCommands()) {
+                                                    ctx.getSource().sendFeedback(() -> Text.literal("Removed " + name + " from identity whitelist"), true);
+                                                }
+                                                return 1;
+                                            })))
+                            .build();
+
             rootNode.addChild(grantNode);
             rootNode.addChild(revokeNode);
             rootNode.addChild(equip);
             rootNode.addChild(unequip);
             rootNode.addChild(test);
             rootNode.addChild(offsetNode);
+            rootNode.addChild(whitelistNode);
 
             dispatcher.getRoot().addChild(rootNode);
         });

--- a/fabric/src/main/java/draylar/identity/fabric/config/IdentityFabricConfig.java
+++ b/fabric/src/main/java/draylar/identity/fabric/config/IdentityFabricConfig.java
@@ -342,6 +342,11 @@ public class IdentityFabricConfig extends IdentityConfig implements Config {
     }
 
     @Override
+    public void setEnableSwaps(boolean enabled) {
+        this.enableSwaps = enabled;
+    }
+
+    @Override
     public List<String> allowedSwappers() {
         return allowedSwappers;
     }

--- a/forge/src/main/java/draylar/identity/forge/config/IdentityForgeConfig.java
+++ b/forge/src/main/java/draylar/identity/forge/config/IdentityForgeConfig.java
@@ -281,6 +281,11 @@ public class IdentityForgeConfig extends IdentityConfig {
     }
 
     @Override
+    public void setEnableSwaps(boolean enabled) {
+        this.enableSwaps = enabled;
+    }
+
+    @Override
     public List<String> allowedSwappers() {
         return allowedSwappers;
     }


### PR DESCRIPTION
## Summary
- allow runtime toggling of morph whitelist
- add `/identity whitelist` commands to enable/disable and add or remove players

## Testing
- `gradle build` *(fails: Could not create an instance of type net.fabricmc.loom.extension.LoomProblemReporter)*

------
https://chatgpt.com/codex/tasks/task_e_6890ce390c608331b31f701444fec662