### PR TITLE
Ensure flight revocation updates abilities

### DIFF
--- a/common/src/main/java/draylar/identity/api/FlightHelper.java
+++ b/common/src/main/java/draylar/identity/api/FlightHelper.java
@@ -13,10 +13,10 @@ public class FlightHelper {
     }
 
     public static void revokeFlight(ServerPlayerEntity player) {
-        if(player.interactionManager.isSurvivalLike()) {
+        if (!player.isCreative() && !player.isSpectator()) {
             player.getAbilities().allowFlying = false;
         }
-
         player.getAbilities().flying = false;
+        player.sendAbilitiesUpdate();
     }
 }


### PR DESCRIPTION
## Summary
- ensure flight revocation clears flying permission for non-creative players and syncs abilities

## Testing
- `gradle build` *(fails: Could not create LoomGradleExtensionImpl)*

------
https://chatgpt.com/codex/tasks/task_e_68913d2bbbd48331b82c36aa12809a79