### PR TITLE
Store identity type when morphing to track entity variants

### DIFF
--- a/common/src/main/java/draylar/identity/api/PlayerIdentity.java
+++ b/common/src/main/java/draylar/identity/api/PlayerIdentity.java
@@ -43,14 +43,16 @@ public class PlayerIdentity {
      */
     public static boolean updateIdentity(ServerPlayerEntity player, IdentityType<?> type, LivingEntity entity) {
         // Protect against broken dragons from DragonMounts with null breed
-        if(entity==null)
-            return ((PlayerDataProvider) player).updateIdentity(entity);
+        if(entity == null) {
+            ((PlayerDataProvider) player).setIdentityType(type);
+            return ((PlayerDataProvider) player).updateIdentity(null);
+        }
 
-        if (entity.getClass().getName().equals("com.github.kay9.dragonmounts.dragon.TameableDragon")) {
+        if(entity.getClass().getName().equals("com.github.kay9.dragonmounts.dragon.TameableDragon")) {
             try {
                 Method getBreed = entity.getClass().getMethod("getBreed");
                 Object breed = getBreed.invoke(entity);
-                if (breed == null) {
+                if(breed == null) {
                     player.sendMessage(Text.literal("This dragon identity is broken (no breed). Identity not applied."), false);
                     return false;
                 }
@@ -60,7 +62,7 @@ public class PlayerIdentity {
             }
         }
 
-        // Proceed as usual
+        ((PlayerDataProvider) player).setIdentityType(type);
         return ((PlayerDataProvider) player).updateIdentity(entity);
     }
 

--- a/common/src/main/java/draylar/identity/impl/PlayerDataProvider.java
+++ b/common/src/main/java/draylar/identity/impl/PlayerDataProvider.java
@@ -27,4 +27,5 @@ public interface PlayerDataProvider {
     boolean updateIdentity(@Nullable LivingEntity identity);
 
     IdentityType<?> getIdentityType();
+    void setIdentityType(@Nullable IdentityType<?> type);
 }

--- a/common/src/main/java/draylar/identity/mixin/player/PlayerEntityDataMixin.java
+++ b/common/src/main/java/draylar/identity/mixin/player/PlayerEntityDataMixin.java
@@ -250,6 +250,11 @@ public abstract class PlayerEntityDataMixin extends LivingEntity implements Play
         return identityType;
     }
 
+    @Override
+    public void setIdentityType(@Nullable IdentityType<?> type) {
+        identityType = type;
+    }
+
     @Unique
     @Override
     public void setIdentity(LivingEntity identity) {


### PR DESCRIPTION
## Summary
- Track the specific IdentityType when a player morphs so variant information persists
- Expose a new setter on PlayerDataProvider to update stored IdentityType

## Testing
- `gradle build` *(fails: Could not create an instance of type net.fabricmc.loom.extension.LoomGradleExtensionImpl)*

------
https://chatgpt.com/codex/tasks/task_e_6895f389e59c83319c28a7c2e7ae3916