### PR TITLE
Add mod menu and Forge config screens

### DIFF
--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -37,6 +37,10 @@ dependencies {
     modImplementation include ("dev.draylar.omega-config:omega-config-base:1.4.0+1.20.1") {
         exclude group: "net.fabricmc.fabric-api"
     }
+    modImplementation "com.terraformersmc:modmenu:${rootProject.modmenu_version}"
+    modImplementation include("me.shedaniel.cloth:cloth-config-fabric:${rootProject.cloth_config_version}") {
+        exclude group: "net.fabricmc.fabric-api"
+    }
 }
 
 processResources {

--- a/fabric/src/main/java/draylar/identity/fabric/IdentityModMenuIntegration.java
+++ b/fabric/src/main/java/draylar/identity/fabric/IdentityModMenuIntegration.java
@@ -1,0 +1,15 @@
+package draylar.identity.fabric;
+
+import com.terraformersmc.modmenu.api.ConfigScreenFactory;
+import com.terraformersmc.modmenu.api.ModMenuApi;
+import draylar.identity.fabric.config.IdentityFabricConfig;
+import draylar.omegaconfig.OmegaConfig;
+
+public class IdentityModMenuIntegration implements ModMenuApi {
+
+    @Override
+    public ConfigScreenFactory<?> getModConfigScreenFactory() {
+        return parent -> OmegaConfig.getConfigScreen(IdentityFabricConfig.class, parent);
+    }
+}
+

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -1,36 +1,42 @@
 {
-  "schemaVersion": 1,
-  "id": "identity",
-  "version": "${version}",
-  "name": "Identity",
-  "description": "Play as your favorite entities!",
-  "authors": [
-    "Draylar",
-    "Gaboouu"
-  ],
-  "contributors": [
-    "James103",
-    "Pyrofab",
-    "AllanChain"
-  ],
-  "license": "MIT",
-  "icon": "assets/identity/icon.png",
-  "environment": "*",
-  "entrypoints": {
-    "main": [
-      "draylar.identity.fabric.IdentityFabric"
+    "schemaVersion": 1,
+    "id": "identity",
+    "version": "${version}",
+    "name": "Identity",
+    "description": "Play as your favorite entities!",
+    "authors": [
+        "Draylar",
+        "Gaboouu"
     ],
-    "client": [
-      "draylar.identity.fabric.IdentityFabricClient"
-    ]
-  },
-  "mixins": [
-    "identity.mixins.json",
-    "identity-fabric.mixins.json"
-  ],
-  "depends": {
-    "fabricloader": ">=0.8.7+build.201",
-    "fabric": "*",
-    "architectury": "*"
-  }
+    "contributors": [
+        "James103",
+        "Pyrofab",
+        "AllanChain"
+    ],
+    "license": "MIT",
+    "icon": "assets/identity/icon.png",
+    "environment": "*",
+    "entrypoints": {
+        "main": [
+            "draylar.identity.fabric.IdentityFabric"
+        ],
+        "client": [
+            "draylar.identity.fabric.IdentityFabricClient"
+        ],
+        "modmenu": [
+            "draylar.identity.fabric.IdentityModMenuIntegration"
+        ]
+    },
+    "mixins": [
+        "identity.mixins.json",
+        "identity-fabric.mixins.json"
+    ],
+    "depends": {
+        "fabricloader": ">=0.8.7+build.201",
+        "fabric": "*",
+        "architectury": "*"
+    },
+    "suggests": {
+        "modmenu": "*"
+    }
 }

--- a/forge/src/main/java/draylar/identity/forge/IdentityForge.java
+++ b/forge/src/main/java/draylar/identity/forge/IdentityForge.java
@@ -8,8 +8,10 @@ import draylar.identity.forge.ability.AlexsMobsAbilityRegistry;
 import draylar.identity.forge.config.ConfigLoader;
 import draylar.identity.forge.config.ForgeConfigReloader;
 import draylar.identity.forge.config.IdentityForgeConfig;
+import draylar.identity.forge.config.IdentityForgeConfigScreen;
 import draylar.identity.util.IdentityCompatUtils;
-import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.client.ConfigGuiHandler;
+import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
@@ -33,7 +35,9 @@ public class IdentityForge {
 //        if (ModList.get().isLoaded("bjornlib")) {
 //            ForgeLivingEntityCompatProvider.init(); // qui utilise Bjorn
 //        }
-        if(Platform.getEnv().isClient()) {
+        if (Platform.getEnv().isClient()) {
+            ModLoadingContext.get().registerExtensionPoint(ConfigGuiHandler.ConfigGuiFactory.class,
+                    () -> new ConfigGuiHandler.ConfigGuiFactory((mc, screen) -> new IdentityForgeConfigScreen(screen)));
             new IdentityForgeClient();
         }
     }

--- a/forge/src/main/java/draylar/identity/forge/config/ConfigLoader.java
+++ b/forge/src/main/java/draylar/identity/forge/config/ConfigLoader.java
@@ -55,6 +55,12 @@ public class ConfigLoader {
         }
     }
 
+    public static void save(IdentityForgeConfig config) {
+        Path configFolder = Platform.getConfigFolder();
+        Path configFile = Paths.get(configFolder.toString(), "identity.json");
+        writeConfigFile(configFile, config);
+    }
+
     private static void writeConfigFile(Path file, IdentityForgeConfig config) {
         try {
             if (!Files.exists(file)) {

--- a/forge/src/main/java/draylar/identity/forge/config/IdentityForgeConfigScreen.java
+++ b/forge/src/main/java/draylar/identity/forge/config/IdentityForgeConfigScreen.java
@@ -1,0 +1,101 @@
+package draylar.identity.forge.config;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import draylar.identity.forge.IdentityForge;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.client.gui.widget.TextFieldWidget;
+import net.minecraft.text.Text;
+
+public class IdentityForgeConfigScreen extends Screen {
+    private final Screen parent;
+    private TextFieldWidget extraAquaticBox;
+    private TextFieldWidget removedAquaticBox;
+    private TextFieldWidget extraFlyingBox;
+    private TextFieldWidget removedFlyingBox;
+
+    public IdentityForgeConfigScreen(Screen parent) {
+        super(Text.literal("Identity Config"));
+        this.parent = parent;
+    }
+
+    @Override
+    protected void init() {
+        IdentityForgeConfig config = IdentityForge.CONFIG;
+        int centerX = this.width / 2;
+        int y = 40;
+
+        extraAquaticBox = new TextFieldWidget(textRenderer, centerX - 100, y, 200, 20, Text.empty());
+        extraAquaticBox.setText(String.join(",", config.extraAquaticEntities()));
+        addDrawableChild(extraAquaticBox);
+        y += 30;
+
+        removedAquaticBox = new TextFieldWidget(textRenderer, centerX - 100, y, 200, 20, Text.empty());
+        removedAquaticBox.setText(String.join(",", config.removedAquaticEntities()));
+        addDrawableChild(removedAquaticBox);
+        y += 30;
+
+        extraFlyingBox = new TextFieldWidget(textRenderer, centerX - 100, y, 200, 20, Text.empty());
+        extraFlyingBox.setText(String.join(",", config.extraFlyingEntities()));
+        addDrawableChild(extraFlyingBox);
+        y += 30;
+
+        removedFlyingBox = new TextFieldWidget(textRenderer, centerX - 100, y, 200, 20, Text.empty());
+        removedFlyingBox.setText(String.join(",", config.removedFlyingEntities()));
+        addDrawableChild(removedFlyingBox);
+
+        addDrawableChild(ButtonWidget.builder(Text.translatable("gui.done"), button -> {
+            saveChanges();
+            if (client != null) {
+                client.setScreen(parent);
+            }
+        }).dimensions(centerX - 100, this.height - 28, 200, 20).build());
+    }
+
+    private void saveChanges() {
+        IdentityForgeConfig config = IdentityForge.CONFIG;
+        config.extraAquaticEntities().clear();
+        config.extraAquaticEntities().addAll(split(extraAquaticBox.getText()));
+
+        config.removedAquaticEntities().clear();
+        config.removedAquaticEntities().addAll(split(removedAquaticBox.getText()));
+
+        config.extraFlyingEntities().clear();
+        config.extraFlyingEntities().addAll(split(extraFlyingBox.getText()));
+
+        config.removedFlyingEntities().clear();
+        config.removedFlyingEntities().addAll(split(removedFlyingBox.getText()));
+
+        ConfigLoader.save(config);
+    }
+
+    private List<String> split(String text) {
+        return Arrays.stream(text.split(","))
+            .map(String::trim)
+            .filter(s -> !s.isEmpty())
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    public void render(DrawContext context, int mouseX, int mouseY, float delta) {
+        renderBackground(context);
+        int centerX = this.width / 2;
+        context.drawText(textRenderer, Text.literal("Extra Aquatic Entities"), centerX - 100, 30, 0xFFFFFF, false);
+        context.drawText(textRenderer, Text.literal("Removed Aquatic Entities"), centerX - 100, 60, 0xFFFFFF, false);
+        context.drawText(textRenderer, Text.literal("Extra Flying Entities"), centerX - 100, 90, 0xFFFFFF, false);
+        context.drawText(textRenderer, Text.literal("Removed Flying Entities"), centerX - 100, 120, 0xFFFFFF, false);
+        super.render(context, mouseX, mouseY, delta);
+    }
+
+    @Override
+    public void close() {
+        if (client != null) {
+            client.setScreen(parent);
+        }
+    }
+}
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,3 +19,5 @@ mixin.debug=true
 geckolib_version = 4.7
 midnightlib_fabric_version = 1.4.1
 midnightlib_forge_version = 1.4.2
+modmenu_version=7.2.2
+cloth_config_version=11.1.118


### PR DESCRIPTION
## Summary
- Integrate OmegaConfig with Mod Menu so players can edit Identity settings in-game
- Add Cloth Config and Mod Menu dependencies
- Provide a Forge config screen for managing aquatic and flying entity lists

## Testing
- `gradle build` *(fails: Could not create an instance of type net.fabricmc.loom.extension.LoomProblemReporter)*

------
https://chatgpt.com/codex/tasks/task_e_68a3418d0bc08331b39be598c108a28b