### PR TITLE
Sync player health after identity swap

### DIFF
--- a/common/src/main/java/draylar/identity/util/AttributeSync.java
+++ b/common/src/main/java/draylar/identity/util/AttributeSync.java
@@ -18,7 +18,7 @@ public class AttributeSync {
                 player.getId(),
                 List.of(player.getAttributes().getCustomInstance(EntityAttributes.GENERIC_MAX_HEALTH))
         );
-
+        player.networkHandler.sendPacket(packet);
         ((ServerWorld) player.getWorld()).getChunkManager().sendToNearbyPlayers(player, packet);
     }
 }


### PR DESCRIPTION
## Summary
- Send max health attribute packets to the player themself to ensure health hearts update when adopting an identity

## Testing
- `gradle build` *(fails: Could not apply dev.architectury.loom plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ce7b2f4c8331977f3a03d5dd8f7a