### PR TITLE
fix: add missing imports to config screen

### DIFF
--- a/forge/src/main/java/draylar/identity/forge/config/IdentityForgeConfigScreen.java
+++ b/forge/src/main/java/draylar/identity/forge/config/IdentityForgeConfigScreen.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import draylar.identity.forge.IdentityForge;
+import draylar.identity.forge.config.ConfigLoader;
+import draylar.identity.forge.config.IdentityForgeConfig;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.widget.ButtonWidget;


### PR DESCRIPTION
## Summary
- add explicit imports for ConfigLoader and IdentityForgeConfig in the Forge config screen

## Testing
- `gradle build` *(fails: Could not apply plugin 'dev.architectury.loom')*

------
https://chatgpt.com/codex/tasks/task_e_68a5d40fd89c8331a03fcc9f6fd70d18