### PR TITLE
Fix health not syncing on respawn

### DIFF
--- a/common/src/main/java/draylar/identity/mixin/PlayerManagerMixin.java
+++ b/common/src/main/java/draylar/identity/mixin/PlayerManagerMixin.java
@@ -32,7 +32,8 @@ public class PlayerManagerMixin {
             method = "respawnPlayer",
             at = @At("RETURN")
     )
-    private void onRespawn(ServerPlayerEntity player, boolean alive, CallbackInfoReturnable<ServerPlayerEntity> cir) {
+    private void onRespawn(ServerPlayerEntity oldPlayer, boolean alive, CallbackInfoReturnable<ServerPlayerEntity> cir) {
+        ServerPlayerEntity player = cir.getReturnValue();
         LivingEntity identity = PlayerIdentity.getIdentity(player);
 
         // refresh entity hitbox dimensions after death

--- a/common/src/main/java/draylar/identity/mixin/player/PlayerManagerMixin.java
+++ b/common/src/main/java/draylar/identity/mixin/player/PlayerManagerMixin.java
@@ -15,7 +15,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public class PlayerManagerMixin {
 
     @Inject(method = "respawnPlayer", at = @At(value = "RETURN"))
-    private void sendResyncPacketOnRespawn(ServerPlayerEntity player, boolean alive, CallbackInfoReturnable<ServerPlayerEntity> cir) {
+    private void sendResyncPacketOnRespawn(ServerPlayerEntity oldPlayer, boolean alive, CallbackInfoReturnable<ServerPlayerEntity> cir) {
+        ServerPlayerEntity player = cir.getReturnValue();
         PlayerUnlocks.sync(player);
         PlayerFavorites.sync(player);
         PlayerIdentity.sync(player);


### PR DESCRIPTION
## Summary
- Reapply respawn logic to the newly created player so identity health matches on respawn
- Resend identity data from the new player instance after respawn

## Testing
- `gradle build` *(fails: Could not create an instance of type net.fabricmc.loom.extension.LoomGradleExtensionImpl)*

------
https://chatgpt.com/codex/tasks/task_e_68a60f087d788331a076fb43d3cad675