### PR TITLE
Skip incompatible identities

### DIFF
--- a/common/src/main/java/draylar/identity/screen/IdentityScreen.java
+++ b/common/src/main/java/draylar/identity/screen/IdentityScreen.java
@@ -87,6 +87,7 @@ public class IdentityScreen extends Screen {
                 LivingEntity e = (LivingEntity) type.create(client.world);
                 renderEntities.put(type, e);
             } catch (Exception e) {
+                IdentityCompatUtils.markIncompatibleEntityType(type.getEntityType());
                 Identity.LOGGER.warn("Failed to create identity " + type.getEntityType().getTranslationKey(), e);
             }
         }
@@ -281,6 +282,7 @@ public class IdentityScreen extends Screen {
                     LivingEntity e = (LivingEntity) type.create(client.world);
                     renderEntities.put(type, e);
                 } catch (Exception e) {
+                    IdentityCompatUtils.markIncompatibleEntityType(type.getEntityType());
                     Identity.LOGGER.warn("Failed to create identity " + type.getEntityType().getTranslationKey(), e);
                 }
             }

--- a/common/src/main/java/draylar/identity/util/IdentityCompatUtils.java
+++ b/common/src/main/java/draylar/identity/util/IdentityCompatUtils.java
@@ -6,17 +6,28 @@ import net.minecraft.entity.EntityType;
 import net.minecraft.registry.Registries;
 import net.minecraft.util.Identifier;
 
+import java.util.HashSet;
+import java.util.Set;
+
 public class IdentityCompatUtils {
+
+    private static final Set<Identifier> INCOMPATIBLE_TYPES = new HashSet<>();
 
     public static boolean isBlacklistedEntityType(EntityType<?> type) {
         Identifier id = Registries.ENTITY_TYPE.getId(type);
 
-        // DEBUG TEMP
-        // Identity.LOGGER.info("Checking identity: " + id);
+        if (INCOMPATIBLE_TYPES.contains(id)) {
+            return true;
+        }
 
         // Blacklist le dragon de Dragon Mounts
-        return id.getNamespace().equals("dragonmounts") &&
-                id.getPath().equals("dragon");
+        return id.getNamespace().equals("dragonmounts") && id.getPath().equals("dragon");
+    }
+
+    public static void markIncompatibleEntityType(EntityType<?> type) {
+        Identifier id = Registries.ENTITY_TYPE.getId(type);
+        INCOMPATIBLE_TYPES.add(id);
+        Identity.LOGGER.warn("Marked incompatible identity {}", id);
     }
     public static boolean isAlexsMobsLoaded() {
 //        for(var d:Platform.getMods())


### PR DESCRIPTION
## Summary
- Track identities that fail to instantiate and mark them incompatible
- Filter incompatible identities from the swap menu and block swaps to them

## Testing
- `gradle build` *(fails: Could not create an instance of type net.fabricmc.loom.extension.LoomGradleExtensionImpl)*

------
https://chatgpt.com/codex/tasks/task_e_68ac871e95c883319fe7c9bb95d7e612