### PR TITLE
Add Guardian ability granting mining fatigue

### DIFF
--- a/common/src/main/java/draylar/identity/ability/AbilityRegistry.java
+++ b/common/src/main/java/draylar/identity/ability/AbilityRegistry.java
@@ -30,6 +30,8 @@ public class AbilityRegistry {
         register(EntityType.WITCH, new WitchAbility());
         register(EntityType.EVOKER, new EvokerAbility());
         register(EntityType.WARDEN, new WardenAbility());
+        register(EntityType.GUARDIAN, new GuardianAbility());
+        register(EntityType.ELDER_GUARDIAN, new GuardianAbility());
     }
 
     public static IdentityAbility get(EntityType<?> type) {

--- a/common/src/main/java/draylar/identity/ability/impl/GuardianAbility.java
+++ b/common/src/main/java/draylar/identity/ability/impl/GuardianAbility.java
@@ -1,0 +1,42 @@
+package draylar.identity.ability.impl;
+
+import draylar.identity.ability.IdentityAbility;
+import net.minecraft.entity.effect.StatusEffectInstance;
+import net.minecraft.entity.effect.StatusEffects;
+import net.minecraft.entity.mob.GuardianEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.Item;
+import net.minecraft.item.Items;
+import net.minecraft.world.World;
+
+import java.util.List;
+
+public class GuardianAbility extends IdentityAbility<GuardianEntity> {
+
+    @Override
+    public void onUse(PlayerEntity player, GuardianEntity identity, World world) {
+        if (!world.isClient) {
+            List<PlayerEntity> targets = world.getNonSpectatingEntities(
+                    PlayerEntity.class,
+                    player.getBoundingBox().expand(50.0D)
+            );
+
+            for (PlayerEntity target : targets) {
+                if (target != player) {
+                    target.addStatusEffect(new StatusEffectInstance(StatusEffects.MINING_FATIGUE, 20 * 60, 2));
+                }
+            }
+        }
+    }
+
+    @Override
+    public Item getIcon() {
+        return Items.PRISMARINE_SHARD;
+    }
+
+    @Override
+    public int getCooldown(GuardianEntity entity) {
+        return 20 * 30;
+    }
+}
+


### PR DESCRIPTION
## Summary
- Implement Guardian identity ability that inflicts Mining Fatigue on nearby players
- Register Guardian and Elder Guardian identities with the new ability

## Testing
- `gradle build` *(fails: Failed to apply plugin 'dev.architectury.loom')*

------
https://chatgpt.com/codex/tasks/task_e_68af26c2b80883318408690760a05b1e