### PR TITLE
feat: villager profession ability scaffolding

### DIFF
--- a/common/src/main/java/draylar/identity/ability/AbilityRegistry.java
+++ b/common/src/main/java/draylar/identity/ability/AbilityRegistry.java
@@ -30,6 +30,7 @@ public class AbilityRegistry {
         register(EntityType.WITCH, new WitchAbility());
         register(EntityType.EVOKER, new EvokerAbility());
         register(EntityType.WARDEN, new WardenAbility());
+        register(EntityType.VILLAGER, new VillagerProfessionAbility());
     }
 
     public static IdentityAbility get(EntityType<?> type) {

--- a/common/src/main/java/draylar/identity/ability/impl/VillagerProfessionAbility.java
+++ b/common/src/main/java/draylar/identity/ability/impl/VillagerProfessionAbility.java
@@ -1,0 +1,45 @@
+package draylar.identity.ability.impl;
+
+import draylar.identity.ability.IdentityAbility;
+import draylar.identity.network.impl.VillagerProfessionPackets;
+import net.minecraft.entity.passive.VillagerEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.Item;
+import net.minecraft.item.Items;
+import net.minecraft.registry.entry.RegistryEntry;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.util.hit.HitResult;
+import net.minecraft.world.World;
+import net.minecraft.world.poi.PointOfInterestType;
+import net.minecraft.world.poi.PointOfInterestTypes;
+
+import java.util.Optional;
+
+public class VillagerProfessionAbility extends IdentityAbility<VillagerEntity> {
+
+    @Override
+    public void onUse(PlayerEntity player, VillagerEntity identity, World world) {
+        if (world.isClient) {
+            return;
+        }
+
+        HitResult result = player.raycast(5.0, 0.0F, false);
+        if (result.getType() != HitResult.Type.BLOCK) {
+            return;
+        }
+
+        BlockHitResult blockResult = (BlockHitResult) result;
+        Optional<RegistryEntry<PointOfInterestType>> poi = PointOfInterestTypes.getTypeForState(world.getBlockState(blockResult.getBlockPos()));
+        if (poi.isPresent() && poi.get().getKey().isPresent()) {
+            Identifier professionId = poi.get().getKey().get().getValue();
+            VillagerProfessionPackets.openScreen((ServerPlayerEntity) player, professionId);
+        }
+    }
+
+    @Override
+    public Item getIcon() {
+        return Items.EMERALD;
+    }
+}

--- a/common/src/main/java/draylar/identity/api/PlayerIdentity.java
+++ b/common/src/main/java/draylar/identity/api/PlayerIdentity.java
@@ -15,6 +15,7 @@ import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.Text;
 
 import java.lang.reflect.Method;
+import java.util.Map;
 
 public class PlayerIdentity {
 
@@ -31,6 +32,18 @@ public class PlayerIdentity {
 
     public static IdentityType<?> getIdentityType(PlayerEntity player) {
         return ((PlayerDataProvider) player).getIdentityType();
+    }
+
+    public static Map<String, NbtCompound> getVillagerIdentities(PlayerEntity player) {
+        return ((PlayerDataProvider) player).getVillagerIdentities();
+    }
+
+    public static void setVillagerIdentity(PlayerEntity player, String key, NbtCompound identity) {
+        ((PlayerDataProvider) player).setVillagerIdentity(key, identity);
+    }
+
+    public static void removeVillagerIdentity(PlayerEntity player, String key) {
+        ((PlayerDataProvider) player).removeVillagerIdentity(key);
     }
 
     /**

--- a/common/src/main/java/draylar/identity/impl/PlayerDataProvider.java
+++ b/common/src/main/java/draylar/identity/impl/PlayerDataProvider.java
@@ -3,10 +3,12 @@ package draylar.identity.impl;
 import draylar.identity.api.variant.IdentityType;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.util.Identifier;
+import net.minecraft.nbt.NbtCompound;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.Set;
+import java.util.Map;
 
 public interface PlayerDataProvider {
 
@@ -28,4 +30,8 @@ public interface PlayerDataProvider {
 
     IdentityType<?> getIdentityType();
     void setIdentityType(@Nullable IdentityType<?> type);
+
+    Map<String, NbtCompound> getVillagerIdentities();
+    void setVillagerIdentity(String key, NbtCompound identity);
+    void removeVillagerIdentity(String key);
 }

--- a/common/src/main/java/draylar/identity/mixin/player/PlayerEntityDataMixin.java
+++ b/common/src/main/java/draylar/identity/mixin/player/PlayerEntityDataMixin.java
@@ -49,6 +49,7 @@ public abstract class PlayerEntityDataMixin extends LivingEntity implements Play
     @Unique private int abilityCooldown = 0;
     @Unique private LivingEntity identity = null;
     @Unique private IdentityType<?> identityType = null;
+    @Unique private final Map<String, NbtCompound> villagerIdentities = new HashMap<>();
 
     private PlayerEntityDataMixin(EntityType<? extends LivingEntity> type, World world) {
         super(type, world);
@@ -114,6 +115,13 @@ public abstract class PlayerEntityDataMixin extends LivingEntity implements Play
 
         // Current Identity
         readCurrentIdentity(tag.getCompound("CurrentIdentity"));
+
+        // Villager Identities
+        villagerIdentities.clear();
+        NbtCompound villagerTag = tag.getCompound("VillagerIdentities");
+        for(String key : villagerTag.getKeys()) {
+            villagerIdentities.put(key, villagerTag.getCompound(key));
+        }
     }
 
     @Inject(method = "writeCustomDataToNbt", at = @At("RETURN"))
@@ -142,6 +150,11 @@ public abstract class PlayerEntityDataMixin extends LivingEntity implements Play
 
         // Current Identity
         tag.put("CurrentIdentity", writeCurrentIdentity(new NbtCompound()));
+
+        // Villager Identities
+        NbtCompound villagerTag = new NbtCompound();
+        villagerIdentities.forEach((key, value) -> villagerTag.put(key, value.copy()));
+        tag.put("VillagerIdentities", villagerTag);
     }
 
     @Unique
@@ -253,6 +266,25 @@ public abstract class PlayerEntityDataMixin extends LivingEntity implements Play
     @Override
     public void setIdentityType(@Nullable IdentityType<?> type) {
         identityType = type;
+    }
+
+    @Override
+    public Map<String, NbtCompound> getVillagerIdentities() {
+        return villagerIdentities;
+    }
+
+    @Override
+    public void setVillagerIdentity(String key, NbtCompound identity) {
+        if(identity == null) {
+            villagerIdentities.remove(key);
+        } else {
+            villagerIdentities.put(key, identity);
+        }
+    }
+
+    @Override
+    public void removeVillagerIdentity(String key) {
+        villagerIdentities.remove(key);
     }
 
     @Unique

--- a/common/src/main/java/draylar/identity/network/ClientNetworking.java
+++ b/common/src/main/java/draylar/identity/network/ClientNetworking.java
@@ -7,6 +7,7 @@ import draylar.identity.impl.DimensionsRefresher;
 import draylar.identity.impl.PlayerDataProvider;
 import draylar.identity.network.impl.FavoritePackets;
 import draylar.identity.network.impl.UnlockPackets;
+import draylar.identity.network.impl.VillagerProfessionPackets;
 import io.netty.buffer.Unpooled;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
@@ -26,6 +27,7 @@ public class ClientNetworking implements NetworkHandler {
         NetworkManager.registerReceiver(NetworkManager.Side.S2C, NetworkHandler.ABILITY_SYNC, ClientNetworking::handleAbilitySyncPacket);
         NetworkManager.registerReceiver(NetworkManager.Side.S2C, NetworkHandler.UNLOCK_SYNC, UnlockPackets::handleUnlockSyncPacket);
         NetworkManager.registerReceiver(NetworkManager.Side.S2C, NetworkHandler.CONFIG_SYNC, ClientNetworking::handleConfigurationSyncPacket);
+        VillagerProfessionPackets.registerClientHandler();
     }
 
     public static void runOrQueue(NetworkManager.PacketContext context, ApplicablePacket packet) {

--- a/common/src/main/java/draylar/identity/network/NetworkHandler.java
+++ b/common/src/main/java/draylar/identity/network/NetworkHandler.java
@@ -13,4 +13,7 @@ public interface NetworkHandler {
     Identifier ABILITY_SYNC = Identity.id("ability_sync");
     Identifier CONFIG_SYNC = Identity.id("config_sync");
     Identifier UNLOCK_SYNC = Identity.id("unlock_sync");
+    Identifier OPEN_PROFESSION_SCREEN = Identity.id("open_profession_screen");
+    Identifier SET_PROFESSION = Identity.id("set_profession");
+    Identifier START_TRADE = Identity.id("start_trade");
 }

--- a/common/src/main/java/draylar/identity/network/ServerNetworking.java
+++ b/common/src/main/java/draylar/identity/network/ServerNetworking.java
@@ -6,6 +6,8 @@ import draylar.identity.api.PlayerIdentity;
 import draylar.identity.api.PlayerAbilities;
 import draylar.identity.network.impl.FavoritePackets;
 import draylar.identity.network.impl.SwapPackets;
+import draylar.identity.network.impl.VillagerProfessionPackets;
+import draylar.identity.network.impl.VillagerTradePackets;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
@@ -17,6 +19,8 @@ public class ServerNetworking implements NetworkHandler {
         FavoritePackets.registerFavoriteRequestHandler();
         SwapPackets.registerIdentityRequestPacketHandler();
         SwapPackets.registerIdentityRequestPacketHandler();
+        VillagerProfessionPackets.registerServerHandler();
+        VillagerTradePackets.registerTradeRequestHandler();
     }
 
     public static void registerUseAbilityPacketHandler() {

--- a/common/src/main/java/draylar/identity/network/impl/VillagerProfessionPackets.java
+++ b/common/src/main/java/draylar/identity/network/impl/VillagerProfessionPackets.java
@@ -1,0 +1,69 @@
+package draylar.identity.network.impl;
+
+import dev.architectury.networking.NetworkManager;
+import draylar.identity.api.PlayerIdentity;
+import draylar.identity.impl.PlayerDataProvider;
+import draylar.identity.network.ClientNetworking;
+import draylar.identity.network.NetworkHandler;
+import draylar.identity.screen.VillagerProfessionScreen;
+import io.netty.buffer.Unpooled;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.entity.passive.VillagerEntity;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.Identifier;
+import net.minecraft.text.Text;
+
+public class VillagerProfessionPackets {
+
+    public static void openScreen(ServerPlayerEntity player, Identifier professionId) {
+        PacketByteBuf packet = new PacketByteBuf(Unpooled.buffer());
+        packet.writeIdentifier(professionId);
+        NetworkManager.sendToPlayer(player, NetworkHandler.OPEN_PROFESSION_SCREEN, packet);
+    }
+
+    public static void sendSetProfession(Identifier professionId, String name, boolean reset) {
+        PacketByteBuf packet = new PacketByteBuf(Unpooled.buffer());
+        packet.writeIdentifier(professionId);
+        packet.writeString(name);
+        packet.writeBoolean(reset);
+        NetworkManager.sendToServer(NetworkHandler.SET_PROFESSION, packet);
+    }
+
+    public static void registerServerHandler() {
+        NetworkManager.registerReceiver(NetworkManager.Side.C2S, NetworkHandler.SET_PROFESSION, (buf, context) -> {
+            Identifier professionId = buf.readIdentifier();
+            String name = buf.readString();
+            boolean reset = buf.readBoolean();
+            ServerPlayerEntity player = (ServerPlayerEntity) context.getPlayer();
+
+            context.getPlayer().getServer().execute(() -> {
+                if (reset) {
+                    ((PlayerDataProvider) player).removeVillagerIdentity(name);
+                    PlayerIdentity.updateIdentity(player, null, null);
+                } else {
+                    boolean exists = ((PlayerDataProvider) player).getVillagerIdentities().values().stream().anyMatch(c -> c.getString("ProfessionId").equals(professionId.toString()));
+                    if (exists) {
+                        player.sendMessage(Text.translatable("identity.profession.duplicate"), false);
+                        return;
+                    }
+                    if (PlayerIdentity.getIdentity(player) instanceof VillagerEntity villager) {
+                        NbtCompound tag = new NbtCompound();
+                        villager.writeNbt(tag);
+                        tag.putString("ProfessionId", professionId.toString());
+                        ((PlayerDataProvider) player).setVillagerIdentity(name, tag);
+                        PlayerIdentity.updateIdentity(player, null, null);
+                    }
+                }
+            });
+        });
+    }
+
+    public static void registerClientHandler() {
+        NetworkManager.registerReceiver(NetworkManager.Side.S2C, NetworkHandler.OPEN_PROFESSION_SCREEN, (buf, context) -> {
+            Identifier professionId = buf.readIdentifier();
+            ClientNetworking.runOrQueue(context, player -> MinecraftClient.getInstance().setScreen(new VillagerProfessionScreen(professionId)));
+        });
+    }
+}

--- a/common/src/main/java/draylar/identity/network/impl/VillagerTradePackets.java
+++ b/common/src/main/java/draylar/identity/network/impl/VillagerTradePackets.java
@@ -1,0 +1,37 @@
+package draylar.identity.network.impl;
+
+import dev.architectury.networking.NetworkManager;
+import draylar.identity.api.PlayerIdentity;
+import draylar.identity.network.NetworkHandler;
+import io.netty.buffer.Unpooled;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.passive.VillagerEntity;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.server.network.ServerPlayerEntity;
+
+import java.util.UUID;
+
+public class VillagerTradePackets {
+
+    public static void sendTradeRequest(UUID target) {
+        PacketByteBuf packet = new PacketByteBuf(Unpooled.buffer());
+        packet.writeUuid(target);
+        NetworkManager.sendToServer(NetworkHandler.START_TRADE, packet);
+    }
+
+    public static void registerTradeRequestHandler() {
+        NetworkManager.registerReceiver(NetworkManager.Side.C2S, NetworkHandler.START_TRADE, (buf, context) -> {
+            UUID targetId = buf.readUuid();
+            ServerPlayerEntity requester = (ServerPlayerEntity) context.getPlayer();
+            context.getPlayer().getServer().execute(() -> {
+                ServerPlayerEntity target = requester.getServer().getPlayerManager().getPlayer(targetId);
+                if (target != null) {
+                    LivingEntity identity = PlayerIdentity.getIdentity(target);
+                    if (identity instanceof VillagerEntity villager) {
+                        requester.openHandledScreen(villager);
+                    }
+                }
+            });
+        });
+    }
+}

--- a/common/src/main/java/draylar/identity/screen/VillagerProfessionScreen.java
+++ b/common/src/main/java/draylar/identity/screen/VillagerProfessionScreen.java
@@ -1,0 +1,51 @@
+package draylar.identity.screen;
+
+import draylar.identity.network.impl.VillagerProfessionPackets;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.client.gui.widget.TextFieldWidget;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+
+public class VillagerProfessionScreen extends Screen {
+
+    private final Identifier professionId;
+    private TextFieldWidget nameField;
+
+    public VillagerProfessionScreen(Identifier professionId) {
+        super(Text.translatable("identity.profession.title"));
+        this.professionId = professionId;
+    }
+
+    @Override
+    protected void init() {
+        int centerX = width / 2;
+        int centerY = height / 2;
+        nameField = new TextFieldWidget(textRenderer, centerX - 100, centerY - 10, 200, 20, Text.empty());
+        addSelectableChild(nameField);
+        addDrawableChild(ButtonWidget.builder(Text.translatable("identity.profession.confirm"), button -> {
+            VillagerProfessionPackets.sendSetProfession(professionId, nameField.getText(), false);
+            close();
+        }).dimensions(centerX - 100, centerY + 20, 98, 20).build());
+        addDrawableChild(ButtonWidget.builder(Text.translatable("identity.profession.reset"), button -> {
+            VillagerProfessionPackets.sendSetProfession(professionId, "", true);
+            close();
+        }).dimensions(centerX + 2, centerY + 20, 98, 20).build());
+        setInitialFocus(nameField);
+    }
+
+    @Override
+    public void render(DrawContext context, int mouseX, int mouseY, float delta) {
+        renderBackground(context);
+        super.render(context, mouseX, mouseY, delta);
+        context.drawCenteredTextWithShadow(textRenderer, title, width / 2, height / 2 - 30, 0xFFFFFF);
+        nameField.render(context, mouseX, mouseY, delta);
+    }
+
+    @Override
+    public void close() {
+        MinecraftClient.getInstance().setScreen(null);
+    }
+}

--- a/common/src/main/resources/assets/identity/lang/en_us.json
+++ b/common/src/main/resources/assets/identity/lang/en_us.json
@@ -27,5 +27,9 @@
   "identity.help.return": "Press any key to return to the Identity menu.",
   "key.categories.identity": "Identity",
   "key.identity": "Open Identity Menu",
-  "key.identity_ability": "Use an Identity Ability"
+    "key.identity_ability": "Use an Identity Ability",
+    "identity.profession.title": "Villager Profession",
+    "identity.profession.confirm": "Confirm",
+    "identity.profession.reset": "Reset",
+    "identity.profession.duplicate": "You already have this profession"
 }


### PR DESCRIPTION
## Summary
- add villager profession ability to detect workstations and trigger a profession UI
- implement naming/reset UI with network sync and duplicate profession protection
- scaffold server-side trade packet handling for villager identities

## Testing
- `sudo apt-get install -y apt-utils openjdk-17-jdk` *(fails: ca-certificates-java post-installation script)*
- `gradle build` *(fails: Could not create an instance of type net.fabricmc.loom.extension.LoomGradleExtensionImpl)*

------
https://chatgpt.com/codex/tasks/task_e_68af281ac4e883319ab3bcb7e883604a