### PR TITLE
Add runtime Identity config editing commands

### DIFF
--- a/common/src/main/java/draylar/identity/api/platform/ConfigReloader.java
+++ b/common/src/main/java/draylar/identity/api/platform/ConfigReloader.java
@@ -2,4 +2,6 @@ package draylar.identity.api.platform;
 
 public interface ConfigReloader {
     void reloadConfig();
+
+    void saveConfig();
 }

--- a/common/src/main/java/draylar/identity/api/platform/IdentityConfig.java
+++ b/common/src/main/java/draylar/identity/api/platform/IdentityConfig.java
@@ -1,6 +1,7 @@
 package draylar.identity.api.platform;
 
 import dev.architectury.injectables.annotations.ExpectPlatform;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.Map;
@@ -110,4 +111,65 @@ public abstract class IdentityConfig {
 
     public abstract List<String> removedFlyingEntities();
 
+    public abstract void setOverlayIdentityUnlocks(boolean value);
+
+    public abstract void setOverlayIdentityRevokes(boolean value);
+
+    public abstract void setRevokeIdentityOnDeath(boolean value);
+
+    public abstract void setIdentitiesEquipItems(boolean value);
+
+    public abstract void setIdentitiesEquipArmor(boolean value);
+
+    public abstract void setShowPlayerNametag(boolean value);
+
+    public abstract void setRenderOwnNameTag(boolean value);
+
+    public abstract void setHostilesIgnoreHostileIdentityPlayer(boolean value);
+
+    public abstract void setHostilesForgetNewHostileIdentityPlayer(boolean value);
+
+    public abstract void setWolvesAttackIdentityPrey(boolean value);
+
+    public abstract void setOwnedWolvesAttackIdentityPrey(boolean value);
+
+    public abstract void setVillagersRunFromIdentities(boolean value);
+
+    public abstract void setFoxesAttackIdentityPrey(boolean value);
+
+    public abstract void setUseIdentitySounds(boolean value);
+
+    public abstract void setPlayAmbientSounds(boolean value);
+
+    public abstract void setHearSelfAmbient(boolean value);
+
+    public abstract void setEnableFlight(boolean value);
+
+    public abstract void setHostilityTime(int ticks);
+
+    public abstract void setScalingHealth(boolean value);
+
+    public abstract void setMaxHealth(int value);
+
+    public abstract void setEnableClientSwapMenu(boolean value);
+
+    public abstract void setForceChangeNew(boolean value);
+
+    public abstract void setForceChangeAlways(boolean value);
+
+    public abstract void setLogCommands(boolean value);
+
+    public abstract void setFlySpeed(float value);
+
+    public abstract void setKillForIdentity(boolean value);
+
+    public abstract void setRequiredKillsForIdentity(int value);
+
+    public abstract void setEndermanAbilityTeleportDistance(int value);
+
+    public abstract void setWardenIsBlinded(boolean value);
+
+    public abstract void setWardenBlindsNearby(boolean value);
+
+    public abstract void setForcedIdentity(@Nullable String id);
 }

--- a/common/src/main/java/draylar/identity/command/IdentityCommand.java
+++ b/common/src/main/java/draylar/identity/command/IdentityCommand.java
@@ -1,18 +1,25 @@
 package draylar.identity.command;
 
+import com.mojang.brigadier.arguments.BoolArgumentType;
+import com.mojang.brigadier.arguments.FloatArgumentType;
 import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.suggestion.SuggestionProvider;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import dev.architectury.event.events.common.CommandRegistrationEvent;
 import draylar.identity.api.PlayerIdentity;
 import draylar.identity.api.PlayerUnlocks;
 import draylar.identity.api.platform.IdentityConfig;
+import draylar.identity.api.platform.IdentityPlatform;
 import draylar.identity.api.variant.IdentityType;
 import draylar.identity.screen.widget.EntityWidget;
+import net.minecraft.command.CommandRegistryAccess;
 import net.minecraft.command.argument.EntityArgumentType;
 import net.minecraft.command.argument.NbtCompoundArgumentType;
 import net.minecraft.command.argument.RegistryEntryArgumentType;
 import net.minecraft.command.suggestion.SuggestionProviders;
+import net.minecraft.command.CommandSource;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
@@ -27,8 +34,369 @@ import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.IntConsumer;
+import java.util.function.Supplier;
+
 public class IdentityCommand {
 
+    private static final Map<String, Consumer<Boolean>> BOOLEAN_SETTERS = new LinkedHashMap<>();
+    private static final Map<String, IntConsumer> INT_SETTERS = new LinkedHashMap<>();
+    private static final Map<String, Consumer<Float>> FLOAT_SETTERS = new LinkedHashMap<>();
+    private static final List<String> STRING_OPTIONS = new ArrayList<>();
+
+    private static final SuggestionProvider<ServerCommandSource> BOOLEAN_OPTION_SUGGESTIONS = (context, builder) -> CommandSource.suggestMatching(BOOLEAN_SETTERS.keySet(), builder);
+    private static final SuggestionProvider<ServerCommandSource> INT_OPTION_SUGGESTIONS = (context, builder) -> CommandSource.suggestMatching(INT_SETTERS.keySet(), builder);
+    private static final SuggestionProvider<ServerCommandSource> FLOAT_OPTION_SUGGESTIONS = (context, builder) -> CommandSource.suggestMatching(FLOAT_SETTERS.keySet(), builder);
+    private static final SuggestionProvider<ServerCommandSource> STRING_OPTION_SUGGESTIONS = (context, builder) -> CommandSource.suggestMatching(STRING_OPTIONS, builder);
+
+    private static final SuggestionProvider<ServerCommandSource> FORCED_IDENTITY_SUGGESTIONS = (context, builder) -> {
+        List<String> suggestions = new ArrayList<>();
+        suggestions.add("none");
+        Registries.ENTITY_TYPE.getIds().forEach(id -> suggestions.add(id.toString()));
+        return CommandSource.suggestMatching(suggestions, builder);
+    };
+
+    static {
+        BOOLEAN_SETTERS.put("overlay_identity_unlocks", value -> IdentityConfig.getInstance().setOverlayIdentityUnlocks(value));
+        BOOLEAN_SETTERS.put("overlay_identity_revokes", value -> IdentityConfig.getInstance().setOverlayIdentityRevokes(value));
+        BOOLEAN_SETTERS.put("revoke_identity_on_death", value -> IdentityConfig.getInstance().setRevokeIdentityOnDeath(value));
+        BOOLEAN_SETTERS.put("identities_equip_items", value -> IdentityConfig.getInstance().setIdentitiesEquipItems(value));
+        BOOLEAN_SETTERS.put("identities_equip_armor", value -> IdentityConfig.getInstance().setIdentitiesEquipArmor(value));
+        BOOLEAN_SETTERS.put("show_player_nametag", value -> IdentityConfig.getInstance().setShowPlayerNametag(value));
+        BOOLEAN_SETTERS.put("render_own_nametag", value -> IdentityConfig.getInstance().setRenderOwnNameTag(value));
+        BOOLEAN_SETTERS.put("hostiles_ignore_hostile_identity_player", value -> IdentityConfig.getInstance().setHostilesIgnoreHostileIdentityPlayer(value));
+        BOOLEAN_SETTERS.put("hostiles_forget_new_hostile_identity_player", value -> IdentityConfig.getInstance().setHostilesForgetNewHostileIdentityPlayer(value));
+        BOOLEAN_SETTERS.put("wolves_attack_identity_prey", value -> IdentityConfig.getInstance().setWolvesAttackIdentityPrey(value));
+        BOOLEAN_SETTERS.put("owned_wolves_attack_identity_prey", value -> IdentityConfig.getInstance().setOwnedWolvesAttackIdentityPrey(value));
+        BOOLEAN_SETTERS.put("villagers_run_from_identities", value -> IdentityConfig.getInstance().setVillagersRunFromIdentities(value));
+        BOOLEAN_SETTERS.put("foxes_attack_identity_prey", value -> IdentityConfig.getInstance().setFoxesAttackIdentityPrey(value));
+        BOOLEAN_SETTERS.put("use_identity_sounds", value -> IdentityConfig.getInstance().setUseIdentitySounds(value));
+        BOOLEAN_SETTERS.put("play_ambient_sounds", value -> IdentityConfig.getInstance().setPlayAmbientSounds(value));
+        BOOLEAN_SETTERS.put("hear_self_ambient", value -> IdentityConfig.getInstance().setHearSelfAmbient(value));
+        BOOLEAN_SETTERS.put("enable_flight", value -> IdentityConfig.getInstance().setEnableFlight(value));
+        BOOLEAN_SETTERS.put("enable_client_swap_menu", value -> IdentityConfig.getInstance().setEnableClientSwapMenu(value));
+        BOOLEAN_SETTERS.put("enable_swaps", value -> IdentityConfig.getInstance().setEnableSwaps(value));
+        BOOLEAN_SETTERS.put("allow_self_trading", value -> IdentityConfig.getInstance().setAllowSelfTrading(value));
+        BOOLEAN_SETTERS.put("force_change_new", value -> IdentityConfig.getInstance().setForceChangeNew(value));
+        BOOLEAN_SETTERS.put("force_change_always", value -> IdentityConfig.getInstance().setForceChangeAlways(value));
+        BOOLEAN_SETTERS.put("log_commands", value -> IdentityConfig.getInstance().setLogCommands(value));
+        BOOLEAN_SETTERS.put("kill_for_identity", value -> IdentityConfig.getInstance().setKillForIdentity(value));
+        BOOLEAN_SETTERS.put("scaling_health", value -> IdentityConfig.getInstance().setScalingHealth(value));
+        BOOLEAN_SETTERS.put("warden_is_blinded", value -> IdentityConfig.getInstance().setWardenIsBlinded(value));
+        BOOLEAN_SETTERS.put("warden_blinds_nearby", value -> IdentityConfig.getInstance().setWardenBlindsNearby(value));
+
+        INT_SETTERS.put("hostility_time", value -> IdentityConfig.getInstance().setHostilityTime(value));
+        INT_SETTERS.put("max_health", value -> IdentityConfig.getInstance().setMaxHealth(value));
+        INT_SETTERS.put("enderman_ability_teleport_distance", value -> IdentityConfig.getInstance().setEndermanAbilityTeleportDistance(value));
+        INT_SETTERS.put("required_kills_for_identity", value -> IdentityConfig.getInstance().setRequiredKillsForIdentity(value));
+
+        FLOAT_SETTERS.put("fly_speed", value -> IdentityConfig.getInstance().setFlySpeed(value));
+
+        STRING_OPTIONS.add("forced_identity");
+    }
+
+    private static LiteralArgumentBuilder<ServerCommandSource> createListCommand(CommandRegistryAccess registryAccess) {
+        LiteralArgumentBuilder<ServerCommandSource> listBuilder = CommandManager.literal("list");
+
+        listBuilder.then(createStringListNode("allowed_swappers", () -> IdentityConfig.getInstance().allowedSwappers(), true, "player"));
+        listBuilder.then(createStringListNode("advancements_required_for_flight", () -> IdentityConfig.getInstance().advancementsRequiredForFlight(), false, "advancement"));
+        listBuilder.then(createEntityListNode("extra_aquatic_entities", () -> IdentityConfig.getInstance().extraAquaticEntities(), registryAccess));
+        listBuilder.then(createEntityListNode("removed_aquatic_entities", () -> IdentityConfig.getInstance().removedAquaticEntities(), registryAccess));
+        listBuilder.then(createEntityListNode("extra_flying_entities", () -> IdentityConfig.getInstance().extraFlyingEntities(), registryAccess));
+        listBuilder.then(createEntityListNode("removed_flying_entities", () -> IdentityConfig.getInstance().removedFlyingEntities(), registryAccess));
+
+        return listBuilder;
+    }
+
+    private static LiteralArgumentBuilder<ServerCommandSource> createMapCommand(CommandRegistryAccess registryAccess) {
+        LiteralArgumentBuilder<ServerCommandSource> mapBuilder = CommandManager.literal("map");
+
+        mapBuilder.then(createAbilityCooldownCommands(registryAccess));
+        mapBuilder.then(createRequiredKillCommands(registryAccess));
+
+        return mapBuilder;
+    }
+
+    private static LiteralArgumentBuilder<ServerCommandSource> createStringListNode(String literal, Supplier<List<String>> listSupplier, boolean caseInsensitive, String valueArgumentName) {
+        return CommandManager.literal(literal)
+                .then(CommandManager.literal("add")
+                        .then(CommandManager.argument(valueArgumentName, StringArgumentType.string())
+                                .executes(ctx -> addToList(ctx.getSource(), listSupplier, caseInsensitive, literal, StringArgumentType.getString(ctx, valueArgumentName)))))
+                .then(CommandManager.literal("remove")
+                        .then(CommandManager.argument(valueArgumentName, StringArgumentType.string())
+                                .suggests((context, builder) -> CommandSource.suggestMatching(new ArrayList<>(listSupplier.get()), builder))
+                                .executes(ctx -> removeFromList(ctx.getSource(), listSupplier, caseInsensitive, literal, StringArgumentType.getString(ctx, valueArgumentName)))))
+                .then(CommandManager.literal("clear")
+                        .executes(ctx -> clearList(ctx.getSource(), listSupplier, literal)));
+    }
+
+    private static LiteralArgumentBuilder<ServerCommandSource> createEntityListNode(String literal, Supplier<List<String>> listSupplier, CommandRegistryAccess registryAccess) {
+        return CommandManager.literal(literal)
+                .then(CommandManager.literal("add")
+                        .then(CommandManager.argument("entity", RegistryEntryArgumentType.registryEntry(registryAccess, RegistryKeys.ENTITY_TYPE)).suggests(SuggestionProviders.SUMMONABLE_ENTITIES)
+                                .executes(ctx -> {
+                                    Identifier id = RegistryEntryArgumentType.getSummonableEntityType(ctx, "entity").registryKey().getValue();
+                                    return addToList(ctx.getSource(), listSupplier, false, literal, id.toString());
+                                })))
+                .then(CommandManager.literal("remove")
+                        .then(CommandManager.argument("entity", StringArgumentType.string())
+                                .suggests((context, builder) -> CommandSource.suggestMatching(new ArrayList<>(listSupplier.get()), builder))
+                                .executes(ctx -> removeFromList(ctx.getSource(), listSupplier, false, literal, StringArgumentType.getString(ctx, "entity")))))
+                .then(CommandManager.literal("clear")
+                        .executes(ctx -> clearList(ctx.getSource(), listSupplier, literal)));
+    }
+
+    private static LiteralArgumentBuilder<ServerCommandSource> createAbilityCooldownCommands(CommandRegistryAccess registryAccess) {
+        return CommandManager.literal("ability_cooldowns")
+                .then(CommandManager.literal("set")
+                        .then(CommandManager.argument("entity", RegistryEntryArgumentType.registryEntry(registryAccess, RegistryKeys.ENTITY_TYPE)).suggests(SuggestionProviders.SUMMONABLE_ENTITIES)
+                                .then(CommandManager.argument("cooldown", IntegerArgumentType.integer(0))
+                                        .executes(ctx -> {
+                                            Identifier id = RegistryEntryArgumentType.getSummonableEntityType(ctx, "entity").registryKey().getValue();
+                                            int cooldown = IntegerArgumentType.getInteger(ctx, "cooldown");
+                                            return setAbilityCooldown(ctx.getSource(), id.toString(), cooldown);
+                                        }))))
+                .then(CommandManager.literal("remove")
+                        .then(CommandManager.argument("entity", StringArgumentType.string())
+                                .suggests((context, builder) -> CommandSource.suggestMatching(IdentityConfig.getInstance().getAbilityCooldownMap().keySet(), builder))
+                                .executes(ctx -> removeAbilityCooldown(ctx.getSource(), StringArgumentType.getString(ctx, "entity")))))
+                .then(CommandManager.literal("clear")
+                        .executes(ctx -> clearAbilityCooldowns(ctx.getSource())));
+    }
+
+    private static LiteralArgumentBuilder<ServerCommandSource> createRequiredKillCommands(CommandRegistryAccess registryAccess) {
+        return CommandManager.literal("required_kills")
+                .then(CommandManager.literal("set")
+                        .then(CommandManager.argument("entity", RegistryEntryArgumentType.registryEntry(registryAccess, RegistryKeys.ENTITY_TYPE)).suggests(SuggestionProviders.SUMMONABLE_ENTITIES)
+                                .then(CommandManager.argument("kills", IntegerArgumentType.integer(0))
+                                        .executes(ctx -> {
+                                            Identifier id = RegistryEntryArgumentType.getSummonableEntityType(ctx, "entity").registryKey().getValue();
+                                            int kills = IntegerArgumentType.getInteger(ctx, "kills");
+                                            return setRequiredKillOverride(ctx.getSource(), id.toString(), kills);
+                                        }))))
+                .then(CommandManager.literal("remove")
+                        .then(CommandManager.argument("entity", StringArgumentType.string())
+                                .suggests((context, builder) -> CommandSource.suggestMatching(IdentityConfig.getInstance().getRequiredKillsByType().keySet(), builder))
+                                .executes(ctx -> removeRequiredKillOverride(ctx.getSource(), StringArgumentType.getString(ctx, "entity")))))
+                .then(CommandManager.literal("clear")
+                        .executes(ctx -> clearRequiredKillOverrides(ctx.getSource())));
+    }
+
+    private static int addToList(ServerCommandSource source, Supplier<List<String>> supplier, boolean caseInsensitive, String listName, String value) {
+        List<String> list = supplier.get();
+        boolean exists = caseInsensitive ? list.stream().anyMatch(entry -> entry.equalsIgnoreCase(value)) : list.contains(value);
+
+        if (exists) {
+            source.sendError(Text.literal(value + " is already present in " + formatKey(listName)));
+            return 0;
+        }
+
+        list.add(value);
+        persistConfig(source, Text.literal("Added " + value + " to " + formatKey(listName)));
+        return 1;
+    }
+
+    private static int removeFromList(ServerCommandSource source, Supplier<List<String>> supplier, boolean caseInsensitive, String listName, String value) {
+        List<String> list = supplier.get();
+        boolean removed;
+
+        if (caseInsensitive) {
+            removed = list.removeIf(entry -> entry.equalsIgnoreCase(value));
+        } else {
+            removed = list.remove(value);
+        }
+
+        if (!removed) {
+            source.sendError(Text.literal(value + " is not present in " + formatKey(listName)));
+            return 0;
+        }
+
+        persistConfig(source, Text.literal("Removed " + value + " from " + formatKey(listName)));
+        return 1;
+    }
+
+    private static int clearList(ServerCommandSource source, Supplier<List<String>> supplier, String listName) {
+        List<String> list = supplier.get();
+
+        if (list.isEmpty()) {
+            source.sendFeedback(() -> Text.literal(formatKey(listName) + " is already empty"), false);
+            return 0;
+        }
+
+        list.clear();
+        persistConfig(source, Text.literal("Cleared " + formatKey(listName)));
+        return 1;
+    }
+
+    private static int setAbilityCooldown(ServerCommandSource source, String entityId, int cooldown) {
+        IdentityConfig.getInstance().getAbilityCooldownMap().put(entityId, cooldown);
+        persistConfig(source, Text.literal("Set ability cooldown for " + entityId + " to " + cooldown));
+        return 1;
+    }
+
+    private static int removeAbilityCooldown(ServerCommandSource source, String entityId) {
+        Integer removed = IdentityConfig.getInstance().getAbilityCooldownMap().remove(entityId);
+        if (removed == null) {
+            source.sendError(Text.literal("No ability cooldown override exists for " + entityId));
+            return 0;
+        }
+
+        persistConfig(source, Text.literal("Removed ability cooldown override for " + entityId));
+        return 1;
+    }
+
+    private static int clearAbilityCooldowns(ServerCommandSource source) {
+        Map<String, Integer> map = IdentityConfig.getInstance().getAbilityCooldownMap();
+        if (map.isEmpty()) {
+            source.sendFeedback(() -> Text.literal("Ability cooldown overrides are already empty"), false);
+            return 0;
+        }
+
+        map.clear();
+        persistConfig(source, Text.literal("Cleared all ability cooldown overrides"));
+        return 1;
+    }
+
+    private static int setRequiredKillOverride(ServerCommandSource source, String entityId, int kills) {
+        IdentityConfig.getInstance().getRequiredKillsByType().put(entityId, kills);
+        persistConfig(source, Text.literal("Set required kills for " + entityId + " to " + kills));
+        return 1;
+    }
+
+    private static int removeRequiredKillOverride(ServerCommandSource source, String entityId) {
+        Integer removed = IdentityConfig.getInstance().getRequiredKillsByType().remove(entityId);
+        if (removed == null) {
+            source.sendError(Text.literal("No required kill override exists for " + entityId));
+            return 0;
+        }
+
+        persistConfig(source, Text.literal("Removed required kill override for " + entityId));
+        return 1;
+    }
+
+    private static int clearRequiredKillOverrides(ServerCommandSource source) {
+        Map<String, Integer> map = IdentityConfig.getInstance().getRequiredKillsByType();
+        if (map.isEmpty()) {
+            source.sendFeedback(() -> Text.literal("Required kill overrides are already empty"), false);
+            return 0;
+        }
+
+        map.clear();
+        persistConfig(source, Text.literal("Cleared all required kill overrides"));
+        return 1;
+    }
+
+    private static int setBooleanOption(ServerCommandSource source, String option, boolean value) {
+        String key = option.toLowerCase(Locale.ROOT);
+        Consumer<Boolean> setter = BOOLEAN_SETTERS.get(key);
+
+        if (setter == null) {
+            source.sendError(Text.literal("Unknown boolean option: " + option));
+            return 0;
+        }
+
+        setter.accept(value);
+        persistConfig(source, Text.literal("Set " + formatKey(key) + " to " + value));
+        return 1;
+    }
+
+    private static int setIntegerOption(ServerCommandSource source, String option, int value) {
+        String key = option.toLowerCase(Locale.ROOT);
+        IntConsumer setter = INT_SETTERS.get(key);
+
+        if (setter == null) {
+            source.sendError(Text.literal("Unknown integer option: " + option));
+            return 0;
+        }
+
+        if ("max_health".equals(key) && value < 1) {
+            source.sendError(Text.literal("max health must be at least 1"));
+            return 0;
+        }
+
+        setter.accept(value);
+        persistConfig(source, Text.literal("Set " + formatKey(key) + " to " + value));
+        return 1;
+    }
+
+    private static int setFloatOption(ServerCommandSource source, String option, float value) {
+        String key = option.toLowerCase(Locale.ROOT);
+        Consumer<Float> setter = FLOAT_SETTERS.get(key);
+
+        if (setter == null) {
+            source.sendError(Text.literal("Unknown float option: " + option));
+            return 0;
+        }
+
+        if (value <= 0) {
+            source.sendError(Text.literal("fly speed must be greater than 0"));
+            return 0;
+        }
+
+        setter.accept(value);
+        persistConfig(source, Text.literal("Set " + formatKey(key) + " to " + value));
+        return 1;
+    }
+
+    private static int setStringOption(ServerCommandSource source, String option, String rawValue) {
+        String key = option.toLowerCase(Locale.ROOT);
+
+        if (!STRING_OPTIONS.contains(key)) {
+            source.sendError(Text.literal("Unknown string option: " + option));
+            return 0;
+        }
+
+        if ("forced_identity".equals(key)) {
+            if (rawValue.equalsIgnoreCase("none") || rawValue.equalsIgnoreCase("null")) {
+                IdentityConfig.getInstance().setForcedIdentity(null);
+                persistConfig(source, Text.literal("Cleared forced identity"));
+                return 1;
+            }
+
+            Identifier identifier = Identifier.tryParse(rawValue);
+            if (identifier == null || !Registries.ENTITY_TYPE.containsId(identifier)) {
+                source.sendError(Text.literal("Unknown entity: " + rawValue));
+                return 0;
+            }
+
+            IdentityConfig.getInstance().setForcedIdentity(identifier.toString());
+            persistConfig(source, Text.literal("Set forced identity to " + identifier));
+            return 1;
+        }
+
+        return 0;
+    }
+
+    private static int reloadConfig(ServerCommandSource source) {
+        if (IdentityPlatform.getReloader() == null) {
+            source.sendError(Text.literal("No config reloader is registered"));
+            return 0;
+        }
+
+        IdentityPlatform.getReloader().reloadConfig();
+        source.sendFeedback(() -> Text.literal("Reloaded Identity config"), true);
+        return 1;
+    }
+
+    private static void persistConfig(ServerCommandSource source, Text message) {
+        source.sendFeedback(() -> message, true);
+
+        if (IdentityPlatform.getReloader() != null) {
+            IdentityPlatform.getReloader().saveConfig();
+        } else {
+            source.sendError(Text.literal("Unable to save config changes because no reloader is registered"));
+        }
+    }
+
+    private static String formatKey(String key) {
+        return key.replace('_', ' ');
+    }
     public static void register() {
         CommandRegistrationEvent.EVENT.register((dispatcher, registryAccess, b) -> {
             LiteralCommandNode<ServerCommandSource> rootNode = CommandManager
@@ -246,6 +614,28 @@ public class IdentityCommand {
                                             })))
                             .build();
 
+            LiteralArgumentBuilder<ServerCommandSource> configBuilder = CommandManager.literal("config")
+                    .then(CommandManager.literal("boolean")
+                            .then(CommandManager.argument("option", StringArgumentType.word()).suggests(BOOLEAN_OPTION_SUGGESTIONS)
+                                    .then(CommandManager.argument("value", BoolArgumentType.bool())
+                                            .executes(ctx -> setBooleanOption(ctx.getSource(), StringArgumentType.getString(ctx, "option"), BoolArgumentType.getBool(ctx, "value"))))))
+                    .then(CommandManager.literal("integer")
+                            .then(CommandManager.argument("option", StringArgumentType.word()).suggests(INT_OPTION_SUGGESTIONS)
+                                    .then(CommandManager.argument("value", IntegerArgumentType.integer(0))
+                                            .executes(ctx -> setIntegerOption(ctx.getSource(), StringArgumentType.getString(ctx, "option"), IntegerArgumentType.getInteger(ctx, "value"))))))
+                    .then(CommandManager.literal("float")
+                            .then(CommandManager.argument("option", StringArgumentType.word()).suggests(FLOAT_OPTION_SUGGESTIONS)
+                                    .then(CommandManager.argument("value", FloatArgumentType.floatArg())
+                                            .executes(ctx -> setFloatOption(ctx.getSource(), StringArgumentType.getString(ctx, "option"), FloatArgumentType.getFloat(ctx, "value"))))))
+                    .then(CommandManager.literal("string")
+                            .then(CommandManager.argument("option", StringArgumentType.word()).suggests(STRING_OPTION_SUGGESTIONS)
+                                    .then(CommandManager.argument("value", StringArgumentType.greedyString()).suggests(FORCED_IDENTITY_SUGGESTIONS)
+                                            .executes(ctx -> setStringOption(ctx.getSource(), StringArgumentType.getString(ctx, "option"), StringArgumentType.getString(ctx, "value"))))))
+                    .then(createListCommand(registryAccess))
+                    .then(createMapCommand(registryAccess))
+                    .then(CommandManager.literal("reload")
+                            .executes(ctx -> reloadConfig(ctx.getSource())));
+
             rootNode.addChild(grantNode);
             rootNode.addChild(revokeNode);
             rootNode.addChild(equip);
@@ -253,6 +643,7 @@ public class IdentityCommand {
             rootNode.addChild(test);
             rootNode.addChild(offsetNode);
             rootNode.addChild(whitelistNode);
+            rootNode.addChild(configBuilder.build());
 
             dispatcher.getRoot().addChild(rootNode);
         });

--- a/fabric/src/main/java/draylar/identity/fabric/config/FabricConfigReloader.java
+++ b/fabric/src/main/java/draylar/identity/fabric/config/FabricConfigReloader.java
@@ -15,4 +15,11 @@ public class FabricConfigReloader implements ConfigReloader {
 
         System.out.println("[Identity] Fabric config reloaded.");
     }
+
+    @Override
+    public void saveConfig() {
+        AutoConfig.getConfigHolder(IdentityFabricConfig.class).save();
+        IdentityFabric.CONFIG = AutoConfig.getConfigHolder(IdentityFabricConfig.class).getConfig();
+        IdentityPlatform.setConfig(IdentityFabric.CONFIG);
+    }
 }

--- a/fabric/src/main/java/draylar/identity/fabric/config/IdentityFabricConfig.java
+++ b/fabric/src/main/java/draylar/identity/fabric/config/IdentityFabricConfig.java
@@ -5,6 +5,7 @@ import draylar.identity.fabric.IdentityFabric;
 import me.shedaniel.autoconfig.ConfigData;
 import me.shedaniel.autoconfig.annotation.Config;
 import me.shedaniel.cloth.clothconfig.shadowed.blue.endless.jankson.Comment;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -370,5 +371,160 @@ public class IdentityFabricConfig extends IdentityConfig implements ConfigData {
     @Override
     public String getForcedIdentity() {
         return null;
+    }
+
+    @Override
+    public void setOverlayIdentityUnlocks(boolean value) {
+        overlayIdentityUnlocks = value;
+    }
+
+    @Override
+    public void setOverlayIdentityRevokes(boolean value) {
+        overlayIdentityRevokes = value;
+    }
+
+    @Override
+    public void setRevokeIdentityOnDeath(boolean value) {
+        revokeIdentityOnDeath = value;
+    }
+
+    @Override
+    public void setIdentitiesEquipItems(boolean value) {
+        identitiesEquipItems = value;
+    }
+
+    @Override
+    public void setIdentitiesEquipArmor(boolean value) {
+        identitiesEquipArmor = value;
+    }
+
+    @Override
+    public void setShowPlayerNametag(boolean value) {
+        showPlayerNametag = value;
+    }
+
+    @Override
+    public void setRenderOwnNameTag(boolean value) {
+        renderOwnNametag = value;
+    }
+
+    @Override
+    public void setHostilesIgnoreHostileIdentityPlayer(boolean value) {
+        hostilesIgnoreHostileIdentityPlayer = value;
+    }
+
+    @Override
+    public void setHostilesForgetNewHostileIdentityPlayer(boolean value) {
+        hostilesForgetNewHostileIdentityPlayer = value;
+    }
+
+    @Override
+    public void setWolvesAttackIdentityPrey(boolean value) {
+        wolvesAttackIdentityPrey = value;
+    }
+
+    @Override
+    public void setOwnedWolvesAttackIdentityPrey(boolean value) {
+        ownedWolvesAttackIdentityPrey = value;
+    }
+
+    @Override
+    public void setVillagersRunFromIdentities(boolean value) {
+        villagersRunFromIdentities = value;
+    }
+
+    @Override
+    public void setFoxesAttackIdentityPrey(boolean value) {
+        foxesAttackIdentityPrey = value;
+    }
+
+    @Override
+    public void setUseIdentitySounds(boolean value) {
+        useIdentitySounds = value;
+    }
+
+    @Override
+    public void setPlayAmbientSounds(boolean value) {
+        playAmbientSounds = value;
+    }
+
+    @Override
+    public void setHearSelfAmbient(boolean value) {
+        hearSelfAmbient = value;
+    }
+
+    @Override
+    public void setEnableFlight(boolean value) {
+        enableFlight = value;
+    }
+
+    @Override
+    public void setHostilityTime(int ticks) {
+        hostilityTime = ticks;
+    }
+
+    @Override
+    public void setScalingHealth(boolean value) {
+        scalingHealth = value;
+    }
+
+    @Override
+    public void setMaxHealth(int value) {
+        maxHealth = value;
+    }
+
+    @Override
+    public void setEnableClientSwapMenu(boolean value) {
+        enableClientSwapMenu = value;
+    }
+
+    @Override
+    public void setForceChangeNew(boolean value) {
+        forceChangeNew = value;
+    }
+
+    @Override
+    public void setForceChangeAlways(boolean value) {
+        forceChangeAlways = value;
+    }
+
+    @Override
+    public void setLogCommands(boolean value) {
+        logCommands = value;
+    }
+
+    @Override
+    public void setFlySpeed(float value) {
+        flySpeed = value;
+    }
+
+    @Override
+    public void setKillForIdentity(boolean value) {
+        killForIdentity = value;
+    }
+
+    @Override
+    public void setRequiredKillsForIdentity(int value) {
+        requiredKillsForIdentity = value;
+    }
+
+    @Override
+    public void setEndermanAbilityTeleportDistance(int value) {
+        endermanAbilityTeleportDistance = value;
+    }
+
+    @Override
+    public void setWardenIsBlinded(boolean value) {
+        wardenIsBlinded = value;
+    }
+
+    @Override
+    public void setWardenBlindsNearby(boolean value) {
+        wardenBlindsNearby = value;
+    }
+
+    @Override
+    public void setForcedIdentity(@Nullable String id) {
+        forcedIdentity = id;
     }
 }

--- a/forge/src/main/java/draylar/identity/forge/config/ForgeConfigReloader.java
+++ b/forge/src/main/java/draylar/identity/forge/config/ForgeConfigReloader.java
@@ -12,4 +12,10 @@ public class ForgeConfigReloader implements ConfigReloader {
 
         System.out.println("[Identity] Forge config reloaded.");
     }
+
+    @Override
+    public void saveConfig() {
+        ConfigLoader.save(IdentityForge.CONFIG);
+        IdentityPlatform.setConfig(IdentityForge.CONFIG);
+    }
 }

--- a/forge/src/main/java/draylar/identity/forge/config/IdentityForgeConfig.java
+++ b/forge/src/main/java/draylar/identity/forge/config/IdentityForgeConfig.java
@@ -344,4 +344,158 @@ public class IdentityForgeConfig extends IdentityConfig {
     }
 
 
+    @Override
+    public void setOverlayIdentityUnlocks(boolean value) {
+        overlayIdentityUnlocks = value;
+    }
+
+    @Override
+    public void setOverlayIdentityRevokes(boolean value) {
+        overlayIdentityRevokes = value;
+    }
+
+    @Override
+    public void setRevokeIdentityOnDeath(boolean value) {
+        revokeIdentityOnDeath = value;
+    }
+
+    @Override
+    public void setIdentitiesEquipItems(boolean value) {
+        identitiesEquipItems = value;
+    }
+
+    @Override
+    public void setIdentitiesEquipArmor(boolean value) {
+        identitiesEquipArmor = value;
+    }
+
+    @Override
+    public void setShowPlayerNametag(boolean value) {
+        showPlayerNametag = value;
+    }
+
+    @Override
+    public void setRenderOwnNameTag(boolean value) {
+        renderOwnNameTag = value;
+    }
+
+    @Override
+    public void setHostilesIgnoreHostileIdentityPlayer(boolean value) {
+        hostilesIgnoreHostileIdentityPlayer = value;
+    }
+
+    @Override
+    public void setHostilesForgetNewHostileIdentityPlayer(boolean value) {
+        hostilesForgetNewHostileIdentityPlayer = value;
+    }
+
+    @Override
+    public void setWolvesAttackIdentityPrey(boolean value) {
+        wolvesAttackIdentityPrey = value;
+    }
+
+    @Override
+    public void setOwnedWolvesAttackIdentityPrey(boolean value) {
+        ownedWolvesAttackIdentityPrey = value;
+    }
+
+    @Override
+    public void setVillagersRunFromIdentities(boolean value) {
+        villagersRunFromIdentities = value;
+    }
+
+    @Override
+    public void setFoxesAttackIdentityPrey(boolean value) {
+        foxesAttackIdentityPrey = value;
+    }
+
+    @Override
+    public void setUseIdentitySounds(boolean value) {
+        useIdentitySounds = value;
+    }
+
+    @Override
+    public void setPlayAmbientSounds(boolean value) {
+        playAmbientSounds = value;
+    }
+
+    @Override
+    public void setHearSelfAmbient(boolean value) {
+        hearSelfAmbient = value;
+    }
+
+    @Override
+    public void setEnableFlight(boolean value) {
+        enableFlight = value;
+    }
+
+    @Override
+    public void setHostilityTime(int ticks) {
+        hostilityTime = ticks;
+    }
+
+    @Override
+    public void setScalingHealth(boolean value) {
+        scalingHealth = value;
+    }
+
+    @Override
+    public void setMaxHealth(int value) {
+        maxHealth = value;
+    }
+
+    @Override
+    public void setEnableClientSwapMenu(boolean value) {
+        enableClientSwapMenu = value;
+    }
+
+    @Override
+    public void setForceChangeNew(boolean value) {
+        forceChangeNew = value;
+    }
+
+    @Override
+    public void setForceChangeAlways(boolean value) {
+        forceChangeAlways = value;
+    }
+
+    @Override
+    public void setLogCommands(boolean value) {
+        logCommands = value;
+    }
+
+    @Override
+    public void setFlySpeed(float value) {
+        flySpeed = value;
+    }
+
+    @Override
+    public void setKillForIdentity(boolean value) {
+        killForIdentity = value;
+    }
+
+    @Override
+    public void setRequiredKillsForIdentity(int value) {
+        requiredKillsForIdentity = value;
+    }
+
+    @Override
+    public void setEndermanAbilityTeleportDistance(int value) {
+        endermanAbilityTeleportDistance = value;
+    }
+
+    @Override
+    public void setWardenIsBlinded(boolean value) {
+        wardenIsBlinded = value;
+    }
+
+    @Override
+    public void setWardenBlindsNearby(boolean value) {
+        wardenBlindsNearby = value;
+    }
+
+    @Override
+    public void setForcedIdentity(String id) {
+        forcedIdentity = id;
+    }
 }


### PR DESCRIPTION
## Summary
- add an `/identity config` command hierarchy that lets operators edit boolean, numeric, list, and map-backed settings at runtime, including entity-aware suggestions
- expose setter APIs on `IdentityConfig` and implement `saveConfig` hooks so platform reloaders can persist runtime changes

## Testing
- `gradle build` *(fails: Could not create an instance of type net.fabricmc.loom.extension.LoomProblemReporter)*

------
https://chatgpt.com/codex/tasks/task_e_68ff75007bac83319467163efac6ca92