### PR TITLE
Document server requirements and enforce Fabric dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,15 @@ This version is actively maintained and updated by me, as the original creator s
 
 |        | Fabric | NeoForge |
 |--------| ----------- | ----------- |
-| 1.20.1 | ✅   | ✅    |
+| 1.21.1 | ✅   | ✅    |
 
-**Required Libraries (1.20.1):**
+**Required Libraries (1.21.1):**
 
 Fabric => [Architectury API (Fabric)](https://www.curseforge.com/minecraft/mc-mods/architectury-fabric)
 
 NeoForge => [Architectury API (NeoForge)](https://www.curseforge.com/minecraft/mc-mods/architectury-neoforge)
+
+> **Server Note:** Identity 1.21.1 targets Minecraft 1.21.x and Java 21. Running the jar on older Minecraft versions or Java runtimes will cause server startup failures. Ensure your dedicated server matches these requirements.
 
 ---
 

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -33,6 +33,8 @@
   ],
   "depends": {
     "fabricloader": ">=0.17.2",
+    "minecraft": ">=1.21.0 <=1.21.1",
+    "java": ">=21",
     "fabric": "*",
     "architectury": "*",
     "gaboulibs": "*"


### PR DESCRIPTION
## Summary
- add explicit Minecraft and Java requirements to the Fabric mod metadata
- update the README to reflect 1.21.1 support and call out the server runtime requirements

## Testing
- gradle build *(fails: missing `apiKey` for project 1238155 in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e0c6badd483319eb7cf3ce6bc8274)