### PR TITLE
Fix flight revoke incompatibility with other mods

### DIFF
--- a/common/src/main/java/draylar/identity/mixin/player/PlayerEntityTickMixin.java
+++ b/common/src/main/java/draylar/identity/mixin/player/PlayerEntityTickMixin.java
@@ -52,17 +52,21 @@ public abstract class PlayerEntityTickMixin extends LivingEntity {
             PlayerAbilities.setCooldown(player, Math.max(0, data.getAbilityCooldown() - 1));
             PlayerAbilities.sync(player);
 
-            // Sync flight abilities with identity state
-            boolean shouldAllowFlight = Identity.hasFlyingPermissions(player);
-            if (shouldAllowFlight != player.getAbilities().allowFlying) {
-                if (shouldAllowFlight) {
-                    FlightHelper.grantFlightTo(player);
-                    player.getAbilities().setFlySpeed(IdentityConfig.getInstance().flySpeed());
-                } else {
-                    FlightHelper.revokeFlight(player);
-                    player.getAbilities().setFlySpeed(0.05f);
+            // Only sync flight state if the player is currently morphed
+            //   to not conflict with other mods that may modify flight state
+            if (identity != null) {
+                // Sync flight abilities with identity state
+                boolean shouldAllowFlight = Identity.hasFlyingPermissions(player);
+                if (shouldAllowFlight != player.getAbilities().allowFlying) {
+                    if (shouldAllowFlight) {
+                        FlightHelper.grantFlightTo(player);
+                        player.getAbilities().setFlySpeed(IdentityConfig.getInstance().flySpeed());
+                    } else {
+                        FlightHelper.revokeFlight(player);
+                        player.getAbilities().setFlySpeed(0.05f);
+                    }
+                    player.sendAbilitiesUpdate();
                 }
-                player.sendAbilitiesUpdate();
             }
 
             // Validate villager profession bindings periodically

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -110,17 +110,22 @@ modrinth {
     }
     uploadFile = file("build/libs/${archivesBaseName}-${version}-fabric.jar")
 }
-curseforge {
-    apiKey = System.getenv("CURSEFORGE_TOKEN")
 
-    project {
-        id = "1238155"
-        changelog = rootProject.file("IdentityChangeLog.md")
-        releaseType = "release" // options: alpha, beta, release
-        addGameVersion "1.20.1"
-        addGameVersion "Fabric"
-        mainArtifact(file("build/libs/${archivesBaseName}-${version}-fabric.jar")) {
-            displayName = "Fabric-${version}"
+var curseforgeToken = System.getenv("CURSEFORGE_TOKEN")
+
+if (curseforgeToken) {
+    curseforge {
+        apiKey = curseforgeToken
+
+        project {
+            id = "1238155"
+            changelog = rootProject.file("IdentityChangeLog.md")
+            releaseType = "release" // options: alpha, beta, release
+            addGameVersion "1.20.1"
+            addGameVersion "Fabric"
+            mainArtifact(file("build/libs/${archivesBaseName}-${version}-fabric.jar")) {
+                displayName = "Fabric-${version}"
+            }
         }
     }
 }

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -112,17 +112,22 @@ modrinth {
     }
     uploadFile = file("build/libs/${archivesBaseName}-${version}-forge.jar")
 }
-curseforge {
-    apiKey = System.getenv("CURSEFORGE_TOKEN")
 
-    project {
-        id = "1238155"
-        changelog = rootProject.file("IdentityChangeLog.md")
-        releaseType = "release" // options: alpha, beta, release
-        addGameVersion "1.20.1"
-        addGameVersion "Forge"
-        mainArtifact(file("build/libs/${archivesBaseName}-${version}-forge.jar")) {
-            displayName = "Forge-${version}"
+var curseforgeToken = System.getenv("CURSEFORGE_TOKEN")
+
+if (curseforgeToken) {
+    curseforge {
+        apiKey = System.getenv("CURSEFORGE_TOKEN")
+
+        project {
+            id = "1238155"
+            changelog = rootProject.file("IdentityChangeLog.md")
+            releaseType = "release" // options: alpha, beta, release
+            addGameVersion "1.20.1"
+            addGameVersion "Forge"
+            mainArtifact(file("build/libs/${archivesBaseName}-${version}-forge.jar")) {
+                displayName = "Forge-${version}"
+            }
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,6 @@
+# Done to increase the memory available to gradle.
+org.gradle.jvmargs=-Xmx4G
+
 # Base Versions
 minecraft_version=1.20.1
 archives_base_name=identity


### PR DESCRIPTION
Commit `472fb124a605f0a2e806ccea04c9afb3c8ca9622` added a change that always updates the flight state each tick (regardless of identity status (whether you have one or not), this caused a conflict with other mods (such as Hex Casting which modify the flying state), this fix remedies that issue by checking whether the player is using an identity before changing and syncing flight state, because in the case of no identity, it will always return false for allowing flight.


Now: with signed commits